### PR TITLE
[npm] prepare new npm version before package release

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "documentation:site": "okidoc-site develop ./docs/site.yml",
     "documentation:site:build": "npm run documentation && okidoc-site build ./docs/site.yml",
     "documentation:site:deploy": "npm run documentation:site:build && gh-pages -d sitedist",
+    "version": "node scripts/npm-version.js",
     "release": "node scripts/npm-release.js",
     "tslint": "ts-node node_modules/.bin/tslint -p . -c tslint.json",
     "tslint:all": "npm run tslint -- '{src,scripts}/**/*.ts'",

--- a/scripts/npm-version.js
+++ b/scripts/npm-version.js
@@ -1,0 +1,39 @@
+const util = require('util');
+const path = require('path');
+const fs = require('fs');
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+
+const packageJSONPath = path.resolve(__dirname, '..', 'package.json');
+const packageJSON = require(packageJSONPath);
+
+// NOTE: pattern for string like 'https://unpkg.com/playable@1.0.0/dist/statics/playable.bundle.min.js'
+const UNPKG_URL_REPLACE_PATTERN = /(https?:\/\/unpkg.com)\/([\w-]+)@(\d+\.\d+\.\d+)\/(.+)/gi;
+
+function replaceUnpkgVersion(markdownString, version) {
+  return markdownString.replace(
+    UNPKG_URL_REPLACE_PATTERN,
+    `$1/$2@${version}/$4`,
+  );
+}
+
+function updateVersionInMarkdown(filePath) {
+  return readFile(filePath).then(content =>
+    writeFile(
+      filePath,
+      replaceUnpkgVersion(content.toString(), packageJSON.version),
+    ),
+  );
+}
+
+const FILES_TO_UPDATE = [
+  path.resolve(__dirname, '../README.md'),
+  path.resolve(__dirname, '../docs/index.md'),
+];
+
+Promise.all(
+  FILES_TO_UPDATE.map(filePath => updateVersionInMarkdown(filePath)),
+).catch(error => {
+  console.error('ERROR: Unable to update version in `md` files', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Added hook for `npm version`

To update version we need run:
```sh
> npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
```
After command run, we have updated version in `package.json` and `md` files + version commit + version tag.

read more: https://docs.npmjs.com/cli/version
