### PR TITLE
add normalize.css styles for playable buttons

### DIFF
--- a/src/default-modules/root-container/normalize/_button.scss
+++ b/src/default-modules/root-container/normalize/_button.scss
@@ -1,0 +1,41 @@
+// https://github.com/necolas/normalize.css/blob/8.0.0/normalize.css#L147-L215
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Show the overflow in IE.
+ * 3. Remove the margin in Firefox and Safari.
+ * 4. Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 5. Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+
+  overflow: visible; /* 2 */
+
+  margin: 0; /* 3 */
+
+  text-transform: none; /* 4 */
+
+  -webkit-appearance: button; /* 5 */
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner {
+  padding: 0;
+
+  border-style: none;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}

--- a/src/default-modules/root-container/normalize/_universal.scss
+++ b/src/default-modules/root-container/normalize/_universal.scss
@@ -1,0 +1,7 @@
+*,
+*:before,
+*:after {
+  box-sizing: content-box;
+
+  outline: none;
+}

--- a/src/default-modules/root-container/root-container.scss
+++ b/src/default-modules/root-container/root-container.scss
@@ -13,19 +13,8 @@
 
   outline: none;
 
-  // NOTE: reset css to initial in player nodes
+  @import './normalize/universal';
   @import './normalize/button';
-  *,
-  *:before,
-  *:after {
-    box-sizing: content-box;
-
-    outline: none;
-  }
-
-  ::-moz-focus-inner {
-    border: 0;
-  }
 
   .fullScreenControl {
     display: none;

--- a/src/default-modules/root-container/root-container.scss
+++ b/src/default-modules/root-container/root-container.scss
@@ -14,6 +14,7 @@
   outline: none;
 
   // NOTE: reset css to initial in player nodes
+  @import './normalize/button';
   *,
   *:before,
   *:after {


### PR DESCRIPTION
- Added `button` part from [normalize.css](https://github.com/necolas/normalize.css/blob/8.0.0/normalize.css)
- Extract universal css normalize rules as `_universal.scss`

Other `normalize` styles could be added by adding `_name.scss` files to `normalize` directory.

```
.
├── root-container.scss
├── /normalize/
│   ├── /_universal.scss
│   ├── /_button.scss
│   ├── /_svg.scss
│   └── ...
└── ...
```