### PR TITLE
chore: generate release notes on `npm version` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to Playable
+
+## Commit Message Guidelines
+
+We use [conventionalcommits](https://conventionalcommits.org/spec/v1.0.0-beta.1.html) to format our commit messages.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**. But also,
+we use the git commit messages to generate the [Playable release notes](https://github.com/wix/playable/releases).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "documentation:site": "okidoc-site develop ./docs/site.yml",
     "documentation:site:build": "npm run documentation && okidoc-site build ./docs/site.yml",
     "documentation:site:deploy": "npm run documentation:site:build && gh-pages -d sitedist",
-    "version": "node scripts/npm-version.js",
+    "version": "node scripts/npm-version.js && conventional-changelog -p angular",
     "postversion": "git push && git push --tags",
     "release": "node scripts/npm-release.js",
     "tslint": "ts-node node_modules/.bin/tslint -p . -c tslint.json",
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "conventional-changelog-cli": "^1.3.22",
     "dashjs": "^2.6.6",
     "eventemitter3": "^3.0.1",
     "hls.js": "^0.9.1",


### PR DESCRIPTION
- add `CONTRIBUTING.md` with notes about [conventionalcommits](https://conventionalcommits.org/spec/v1.0.0-beta.1.html)
- generate release notes on `npm version` script

example of `npm version` output:

```
> npm version

> playable@1.10.3 version /Users/.../playable
> node scripts/npm-version.js && conventional-changelog -p angular

<a name="1.10.3"></a>
## [1.10.3](https://github.com/wix/playable/compare/v1.10.2...v1.10.3) (2018-04-17)

# Bug Fixes

* Overlay shown on STATES.SRC_SET only if video is not playing ([edb34f5](https://github.com/wix/playable/commit/edb34f5))

# Features

* Initial implementation of subtitles module ([194eee0](https://github.com/wix/playable/commit/194eee0))
```

Part of this output should be copied to [new release notes](https://github.com/wix/playable/releases/new)

> NOTE:
chore, style, refactor, docs, ci or build entries will not be in the release notes doe to [next reason](https://github.com/conventional-changelog/standard-version/blob/feature/expain-why-chore-isnt-in-changelog/README.md#why-is-chore-style-refactor-docs-ci-or-build-entries-not-in-my-changelog)